### PR TITLE
Improve docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ It is proposed as a read only replacement for the Hetzner Cloud API in your test
 It is quite easy! Just run:
 
 ```bash
-docker run lkdevelopment/hetzner-cloud-api-mock:latest
+docker run -p 8080:8080 -it lkdevelopment/hetzner-cloud-api-mock:latest
 ```
+
+`-p 8080:8080` maps the internal port of the docker image (8080) to your machine's port (8080). `-it` makes the session interactive so that you can stop it with `CTRL` + `C`.
 
 Then, it runs a basic mock server that is available on Port 8080 by default. So just browse to http://localhost:8080/servers and you get a testable result. All methods that are available in the official documentation are useable on this mock.
 


### PR DESCRIPTION
The `docker run` command in the readme is actually incomplete and doesn't work out of the box for local development :)

I propose these changes:

* expose port 8080 so that it's reachable from the host
* make session interactive so it can receive a SIGTERM